### PR TITLE
Fix Telegram JSON parsing

### DIFF
--- a/routes/referral.py
+++ b/routes/referral.py
@@ -110,7 +110,7 @@ def user_logs():
             "punches": user.get("score", 0),
             "referrals_sent": len([u for u in scores if u.get("referred_by") == user.get("user_id")]),
             "referrals_accepted": len(user.get("referrals", [])),
-            "registered": user.get("referrals", [{}])[0].get("timestamp", "N/A")
+            "registered": user.get("registered_at", "N/A")
         })
 
     html = """
@@ -159,7 +159,7 @@ def user_logs():
                 <th>Punches</th>
                 <th>Referrals Sent</th>
                 <th>Referrals Accepted</th>
-                <th>First Referral Reward Time</th>
+                <th>Registered At</th>
             </tr>
             {% for entry in logs %}
             <tr>

--- a/routes/user.py
+++ b/routes/user.py
@@ -10,7 +10,7 @@ user_routes = Blueprint("user_routes", __name__)
 
 @user_routes.route("/register", methods=["POST"])
 def register():
-    data = request.get_json()
+    data = request.get_json(force=True)
     username = (data.get("username") or "Anonymous").strip()
     first_name = (data.get("first_name") or "").strip()
     last_name = (data.get("last_name") or "").strip()
@@ -35,6 +35,8 @@ def register():
         new_user["referred_by"] = referrer_id
         log_event(f"🧾 {username} was referred by {referrer_id}")
 
+    log_event(f"📝 Registered new user: {username} ({user_id})")
+
     scores.append(new_user)
     save_scores(scores)
     backup_scores()
@@ -46,7 +48,7 @@ user_activity = defaultdict(lambda: deque(maxlen=50))  # Store recent taps
 
 @user_routes.route("/submit", methods=["POST"])
 def submit():
-    data = request.get_json()
+    data = request.get_json(force=True)
     username = (data.get("username") or "Anonymous").strip()
     first_name = (data.get("first_name") or "").strip()
     last_name = (data.get("last_name") or "").strip()


### PR DESCRIPTION
## Summary
- allow JSON parsing without header for /register and /submit
- log all successful registrations
- show registration time on /user-logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68631cb9f530832491a3eab145b60172