### PR TITLE
Fix Telegram JSON parsing

### DIFF
--- a/routes/debug_tools/backups.py
+++ b/routes/debug_tools/backups.py
@@ -3,6 +3,7 @@ import os
 import json
 import time
 from datetime import datetime, timedelta
+from utils.timeutils import toronto_now
 from utils.storage import BACKUP_FOLDER, backup_scores, SCORES_FILE, save_scores
 from utils.logging import log_event
 
@@ -11,7 +12,7 @@ backup_routes = Blueprint("backup_routes", __name__)
 @backup_routes.route("/download-latest-backup", methods=["POST"])
 def download_latest_backup():
     try:
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        timestamp = toronto_now().strftime("%Y%m%d_%H%M%S")
         filename = f"leaderboard_backup_{timestamp}_manual.json"
         backup_scores(tag="manual")
         time.sleep(1)
@@ -39,7 +40,7 @@ def upload_backup():
         file = request.files.get("file")
         if not file or not file.filename.endswith(".json"):
             return "❌ Invalid file.", 400
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        timestamp = toronto_now().strftime("%Y%m%d_%H%M%S")
         save_path = os.path.join(BACKUP_FOLDER, f"leaderboard_backup_{timestamp}.json")
         file.save(save_path)
         log_event(f"✅ Admin uploaded backup {save_path}")
@@ -86,7 +87,7 @@ def preview_backup():
 @backup_routes.route("/backups")
 def view_backups():
     try:
-        cutoff = datetime.now() - timedelta(weeks=3)
+        cutoff = toronto_now() - timedelta(weeks=3)
         files = []
 
         for filename in os.listdir(BACKUP_FOLDER):

--- a/routes/debug_tools/subscriptions.py
+++ b/routes/debug_tools/subscriptions.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify, send_file, render_template_string
-import json, os, datetime
+import json, os
+from utils.timeutils import toronto_now
 from werkzeug.utils import secure_filename
 from utils.logging import log_event
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -16,7 +17,7 @@ def auto_backup_subscriptions():
         return
 
     try:
-        timestamp = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        timestamp = toronto_now().strftime("%Y%m%d-%H%M%S")
         backup_path = os.path.join(BACKUP_DIR, f"auto_daily_{timestamp}.json")
 
         with open(SUB_PATH, "r") as f:
@@ -143,7 +144,6 @@ def download_subscription_backup():
         return "❌ subscriptions.json not found.", 404
     return send_file(SUB_PATH, as_attachment=True)
 
-from utils.logging import log_event  # ✅ Add this at the top if not already
 
 @subscription_routes.route("/subscription-backup/upload", methods=["POST"])
 def upload_subscription_backup():
@@ -160,7 +160,7 @@ def upload_subscription_backup():
 
         # Backup current
         if os.path.exists(SUB_PATH):
-            timestamp = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+            timestamp = toronto_now().strftime("%Y%m%d-%H%M%S")
             backup_path = os.path.join(BACKUP_DIR, f"auto_{timestamp}.json")
             with open(SUB_PATH, "r") as old:
                 with open(backup_path, "w") as bkp:
@@ -198,7 +198,7 @@ def restore_backup():
 
         # Backup current before restoring
         if os.path.exists(SUB_PATH):
-            timestamp = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+            timestamp = toronto_now().strftime("%Y%m%d-%H%M%S")
             with open(SUB_PATH, "r") as cur, open(os.path.join(BACKUP_DIR, f"auto_before_restore_{timestamp}.json"), "w") as bkp:
                 bkp.write(cur.read())
 

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,7 +1,7 @@
 # notifications.py
 import json
 from flask import Blueprint, request, jsonify
-from datetime import datetime
+from utils import utc_timestamp
 
 notifications_routes = Blueprint("notifications_routes", __name__)
 SUBSCRIPTION_PATH = "subscriptions.json"
@@ -46,7 +46,7 @@ def subscribe():
         **subs.get(user_id, {}),
         "subscribed": True,
         "username": username,
-        "subscribed_at": datetime.datetime.utcnow().isoformat()
+        "subscribed_at": utc_timestamp()
     }
 
     with open("subscriptions.json", "w") as f:

--- a/routes/referral.py
+++ b/routes/referral.py
@@ -110,7 +110,7 @@ def user_logs():
             "punches": user.get("score", 0),
             "referrals_sent": len([u for u in scores if u.get("referred_by") == user.get("user_id")]),
             "referrals_accepted": len(user.get("referrals", [])),
-            "registered": user.get("referrals", [{}])[0].get("timestamp", "N/A")
+            "registered": user.get("registered_at", "N/A")
         })
 
     html = """
@@ -159,7 +159,7 @@ def user_logs():
                 <th>Punches</th>
                 <th>Referrals Sent</th>
                 <th>Referrals Accepted</th>
-                <th>First Referral Reward Time</th>
+                <th>Registered At</th>
             </tr>
             {% for entry in logs %}
             <tr>

--- a/routes/user.py
+++ b/routes/user.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request, jsonify
 from utils.storage import load_scores, save_scores, backup_scores
 from utils.logging import log_event
+from utils import normalize_username, user_log_info, utc_timestamp
 import datetime
 from collections import defaultdict, deque
 import time
@@ -10,8 +11,8 @@ user_routes = Blueprint("user_routes", __name__)
 
 @user_routes.route("/register", methods=["POST"])
 def register():
-    data = request.get_json()
-    username = (data.get("username") or "Anonymous").strip()
+    data = request.get_json(force=True)
+    username = normalize_username(data.get("username"))
     first_name = (data.get("first_name") or "").strip()
     last_name = (data.get("last_name") or "").strip()
     user_id = str(data.get("user_id", "")).strip()
@@ -28,12 +29,16 @@ def register():
         "last_name": last_name,
         "user_id": user_id,
         "score": 0,
-        "registered_at": datetime.datetime.now().isoformat()
+        "registered_at": utc_timestamp()
     }
+
+    user_desc = user_log_info(username, first_name, last_name)
 
     if referrer_id:
         new_user["referred_by"] = referrer_id
-        log_event(f"🧾 {username} was referred by {referrer_id}")
+        log_event(f"🧾 {user_desc} was referred by {referrer_id}")
+
+    log_event(f"📝 Registered new user: {user_desc} (ID: {user_id})")
 
     scores.append(new_user)
     save_scores(scores)
@@ -46,12 +51,14 @@ user_activity = defaultdict(lambda: deque(maxlen=50))  # Store recent taps
 
 @user_routes.route("/submit", methods=["POST"])
 def submit():
-    data = request.get_json()
-    username = (data.get("username") or "Anonymous").strip()
+    data = request.get_json(force=True)
+    username = normalize_username(data.get("username"))
     first_name = (data.get("first_name") or "").strip()
     last_name = (data.get("last_name") or "").strip()
     user_id = str(data.get("user_id", "")).strip()
     score = max(0, int(data.get("score", 0)))
+
+    user_desc = user_log_info(username, first_name, last_name)
 
     now = time.time()
 
@@ -61,12 +68,16 @@ def submit():
     if last_time:
         interval = now - last_time
         if interval < 0.2:
-            log_event(f"⚠️ Suspiciously fast tap: {username} (ID: {user_id}) – {interval:.3f}s")
+            log_event(
+                f"⚠️ Suspiciously fast tap: {user_desc} (ID: {user_id}) – {interval:.3f}s"
+            )
 
     user_activity[user_id].append(now)
     recent_taps = [t for t in user_activity[user_id] if now - t <= 10]
     if len(recent_taps) > 30:
-        log_event(f"🚨 High-frequency activity: {username} (ID: {user_id}) – {len(recent_taps)} taps in 10s")
+        log_event(
+            f"🚨 High-frequency activity: {user_desc} (ID: {user_id}) – {len(recent_taps)} taps in 10s"
+        )
 
     scores = load_scores()
     updated = False
@@ -85,7 +96,9 @@ def submit():
                 # 🎯 Bonus for 100s milestone
                 if score % 100 == 0:
                     entry["score"] += 25
-                    log_event(f"🎯 Milestone reached: {score} → +25 bonus punches for {username}")
+                    log_event(
+                        f"🎯 Milestone reached: {score} → +25 bonus punches for {user_desc}"
+                    )
 
                 # 🎁 Referral reward
                 referrer_id = entry.get("referred_by")
@@ -105,7 +118,7 @@ def submit():
                             referrer["score"] += reward
                             entry["score"] += reward
                             entry["referral_reward_issued"] = True
-                            entry["referral_reward_time"] = datetime.datetime.now().isoformat()
+                            entry["referral_reward_time"] = utc_timestamp()
                             updated = True
 
                             if "referrals" not in referrer:
@@ -122,14 +135,30 @@ def submit():
                                 "after_score": referrer["score"]
                             })
 
-                            log_event(f"🎉 Referral bonus issued: {referrer['username']} and {username} +{reward} each at 20 punches")
+                            referrer_desc = user_log_info(
+                                referrer.get('username'),
+                                referrer.get('first_name', ''),
+                                referrer.get('last_name', '')
+                            )
+                            log_event(
+                                f"🎉 Referral bonus issued: {referrer_desc} and {user_desc} +{reward} each at 20 punches"
+                            )
                         else:
-                            log_event(f"⛔ Duplicate referral ignored: {referrer['username']} already rewarded for referring {username}")
+                            referrer_desc = user_log_info(
+                                referrer.get('username'),
+                                referrer.get('first_name', ''),
+                                referrer.get('last_name', '')
+                            )
+                            log_event(
+                                f"⛔ Duplicate referral ignored: {referrer_desc} already rewarded for referring {user_desc}"
+                            )
 
                         # ✅ Reassign updated referrer to ensure persistence
                         scores[referrer_index] = referrer
 
-                log_event(f"✅ Updated score for {username} (ID: {user_id}) to {entry['score']}")
+                log_event(
+                    f"✅ Updated score for {user_desc} (ID: {user_id}) to {entry['score']}"
+                )
             updated = True
             break
 
@@ -140,10 +169,12 @@ def submit():
             "last_name": last_name,
             "user_id": user_id,
             "score": score,
-            "registered_at": datetime.datetime.now().isoformat()
+            "registered_at": utc_timestamp()
         }
         scores.append(entry)
-        log_event(f"🆕 New user added: {username} (ID: {user_id}) with score {score}")
+        log_event(
+            f"🆕 New user added: {user_desc} (ID: {user_id}) with score {score}"
+        )
 
     try:
         save_scores(scores)
@@ -180,7 +211,7 @@ def profile():
 def subscribe_notifications():
     data = request.get_json(force=True)
     user_id = str(data.get("user_id", "")).strip()
-    username = data.get("username", "Anonymous")
+    username = normalize_username(data.get("username"))
 
     scores = load_scores()
     user = next((e for e in scores if e["user_id"] == user_id), None)
@@ -194,12 +225,13 @@ def subscribe_notifications():
     subs[user_id] = {
         "username": username,
         "subscribed": True,
-        "subscribed_at": datetime.datetime.now().isoformat(),
-        "opted_out": False
+        "subscribed_at": utc_timestamp(),
+        "opted_out": False,
     }
     save_subscriptions(subs)
 
-    log_event(f"🔔 Subscribed to notifications: {username} ({user_id})")
+    user_desc = user_log_info(user.get("username"), user.get("first_name", ""), user.get("last_name", ""))
+    log_event(f"🔔 Subscribed to notifications: {user_desc} (ID: {user_id})")
     return jsonify({"status": "subscribed"})
 
 
@@ -224,7 +256,8 @@ def unsubscribe_notifications():
     }
     save_subscriptions(subs)
 
-    log_event(f"🔕 Unsubscribed from notifications: {user.get('username')} ({user_id})")
+    user_desc = user_log_info(user.get("username"), user.get("first_name", ""), user.get("last_name", ""))
+    log_event(f"🔕 Unsubscribed from notifications: {user_desc} (ID: {user_id})")
     return jsonify({"status": "unsubscribed"})
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,4 @@
 # utils/__init__.py
 """Utility package for data storage and logging."""
+from .users import normalize_username, user_log_info
+from .timeutils import utc_timestamp, toronto_now

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,10 +1,10 @@
-import datetime
 import os
+from .timeutils import utc_timestamp
 
 LOG_FILE = "/app/data/logs.txt"
 
 def log_event(message):
-    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = utc_timestamp()
     full = f"[{timestamp}] {message}"
     print(full)  # ✅ Railway console logs
     try:

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -6,6 +6,7 @@ import threading
 import hashlib
 from datetime import datetime
 from .logging import log_event
+from .timeutils import toronto_now, utc_timestamp, TORONTO_TZ
 
 SCORES_FILE = "/app/data/scores.json"
 BACKUP_FOLDER = "/app/data/backups"
@@ -155,7 +156,7 @@ def backup_scores(tag=None):
             log_event("🟡 Skipping backup — no changes since last snapshot.")
             return
 
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")  # use microseconds
+    timestamp = toronto_now().strftime("%Y%m%d_%H%M%S_%f")  # use microseconds
     suffix = f"_{tag}" if tag else ""
     backup_path = os.path.join(BACKUP_FOLDER, f"leaderboard_backup_{timestamp}{suffix}.json")
 

--- a/utils/timeutils.py
+++ b/utils/timeutils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+TORONTO_TZ = ZoneInfo("America/Toronto")
+
+
+def toronto_now() -> datetime:
+    """Return current datetime in the Toronto timezone."""
+    return datetime.now(TORONTO_TZ)
+
+
+def utc_timestamp() -> str:
+    """Current timestamp in UTC derived from Toronto time."""
+    return (
+        toronto_now()
+        .astimezone(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )

--- a/utils/users.py
+++ b/utils/users.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+def normalize_username(username: str | None) -> str:
+    """Ensure username starts with '@' and is stripped."""
+    if not username:
+        return "Anonymous"
+    username = str(username).strip()
+    if username and not username.startswith("@"): 
+        username = "@" + username.lstrip("@")
+    return username
+
+
+def user_log_info(username: str | None, first_name: str = "", last_name: str = "") -> str:
+    """Return formatted string for logs with username and full name."""
+    username = normalize_username(username)
+    full_name = " ".join(part for part in [first_name.strip(), last_name.strip()] if part)
+    return f"{username} ({full_name})" if full_name else username


### PR DESCRIPTION
## Summary
- allow JSON parsing without header for /register and /submit
- log all successful registrations
- show registration time on /user-logs
- ensure logs include username, first name, and last name with @username format
- use Toronto timezone for all timestamps, outputting UTC format

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68631cb9f530832491a3eab145b60172