### PR TITLE
Switch all timestamps to GMT-4

### DIFF
--- a/routes/debug_tools/backups.py
+++ b/routes/debug_tools/backups.py
@@ -3,7 +3,7 @@ import os
 import json
 import time
 from datetime import datetime, timedelta
-from utils.timeutils import toronto_now
+from utils.timeutils import gmt4_now
 from utils.storage import BACKUP_FOLDER, backup_scores, SCORES_FILE, save_scores
 from utils.logging import log_event
 
@@ -12,7 +12,7 @@ backup_routes = Blueprint("backup_routes", __name__)
 @backup_routes.route("/download-latest-backup", methods=["POST"])
 def download_latest_backup():
     try:
-        timestamp = toronto_now().strftime("%Y%m%d_%H%M%S")
+        timestamp = gmt4_now().strftime("%Y%m%d_%H%M%S")
         filename = f"leaderboard_backup_{timestamp}_manual.json"
         backup_scores(tag="manual")
         time.sleep(1)
@@ -40,7 +40,7 @@ def upload_backup():
         file = request.files.get("file")
         if not file or not file.filename.endswith(".json"):
             return "❌ Invalid file.", 400
-        timestamp = toronto_now().strftime("%Y%m%d_%H%M%S")
+        timestamp = gmt4_now().strftime("%Y%m%d_%H%M%S")
         save_path = os.path.join(BACKUP_FOLDER, f"leaderboard_backup_{timestamp}.json")
         file.save(save_path)
         log_event(f"✅ Admin uploaded backup {save_path}")
@@ -87,7 +87,7 @@ def preview_backup():
 @backup_routes.route("/backups")
 def view_backups():
     try:
-        cutoff = toronto_now() - timedelta(weeks=3)
+        cutoff = gmt4_now() - timedelta(weeks=3)
         files = []
 
         for filename in os.listdir(BACKUP_FOLDER):

--- a/routes/debug_tools/subscriptions.py
+++ b/routes/debug_tools/subscriptions.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify, send_file, render_template_string
 import json, os
-from utils.timeutils import toronto_now
+from utils.timeutils import gmt4_now
 from werkzeug.utils import secure_filename
 from utils.logging import log_event
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -17,7 +17,7 @@ def auto_backup_subscriptions():
         return
 
     try:
-        timestamp = toronto_now().strftime("%Y%m%d-%H%M%S")
+        timestamp = gmt4_now().strftime("%Y%m%d-%H%M%S")
         backup_path = os.path.join(BACKUP_DIR, f"auto_daily_{timestamp}.json")
 
         with open(SUB_PATH, "r") as f:
@@ -160,7 +160,7 @@ def upload_subscription_backup():
 
         # Backup current
         if os.path.exists(SUB_PATH):
-            timestamp = toronto_now().strftime("%Y%m%d-%H%M%S")
+            timestamp = gmt4_now().strftime("%Y%m%d-%H%M%S")
             backup_path = os.path.join(BACKUP_DIR, f"auto_{timestamp}.json")
             with open(SUB_PATH, "r") as old:
                 with open(backup_path, "w") as bkp:
@@ -198,7 +198,7 @@ def restore_backup():
 
         # Backup current before restoring
         if os.path.exists(SUB_PATH):
-            timestamp = toronto_now().strftime("%Y%m%d-%H%M%S")
+            timestamp = gmt4_now().strftime("%Y%m%d-%H%M%S")
             with open(SUB_PATH, "r") as cur, open(os.path.join(BACKUP_DIR, f"auto_before_restore_{timestamp}.json"), "w") as bkp:
                 bkp.write(cur.read())
 

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,7 +1,7 @@
 # notifications.py
 import json
 from flask import Blueprint, request, jsonify
-from utils import utc_timestamp
+from utils import gmt4_timestamp
 
 notifications_routes = Blueprint("notifications_routes", __name__)
 SUBSCRIPTION_PATH = "subscriptions.json"
@@ -46,7 +46,7 @@ def subscribe():
         **subs.get(user_id, {}),
         "subscribed": True,
         "username": username,
-        "subscribed_at": utc_timestamp()
+        "subscribed_at": gmt4_timestamp()
     }
 
     with open("subscriptions.json", "w") as f:

--- a/routes/rewards.py
+++ b/routes/rewards.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from flask import Blueprint, request, jsonify, session
 from utils.logging import log_event  # ✅ Logging to logs.txt
 from utils import user_log_info
-from utils import utc_timestamp
+from utils import gmt4_timestamp
 
 rewards_bp = Blueprint("rewards", __name__)
 REWARDS_FILE = "/app/data/rewards.json"
@@ -89,7 +89,7 @@ def log_reward_event(
         return
 
     reward_entry = {
-        "timestamp": utc_timestamp(),
+        "timestamp": gmt4_timestamp(),
         "user_id": user_id,
         "username": username,
         "first_name": first_name,

--- a/routes/user.py
+++ b/routes/user.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify
 from utils.storage import load_scores, save_scores, backup_scores
 from utils.logging import log_event
-from utils import normalize_username, user_log_info, utc_timestamp
+from utils import normalize_username, user_log_info, gmt4_timestamp
 import datetime
 from collections import defaultdict, deque
 import time
@@ -28,7 +28,7 @@ def register():
         "last_name": last_name,
         "user_id": user_id,
         "score": 0,
-        "registered_at": utc_timestamp()
+        "registered_at": gmt4_timestamp()
     }
 
     user_desc = user_log_info(username, first_name, last_name)
@@ -119,7 +119,7 @@ def submit():
                             referrer["score"] += reward
                             entry["score"] += reward
                             entry["referral_reward_issued"] = True
-                            entry["referral_reward_time"] = utc_timestamp()
+                            entry["referral_reward_time"] = gmt4_timestamp()
                             updated = True
 
                             if "referrals" not in referrer:
@@ -170,7 +170,7 @@ def submit():
             "last_name": last_name,
             "user_id": user_id,
             "score": score,
-            "registered_at": utc_timestamp()
+            "registered_at": gmt4_timestamp()
         }
         scores.append(entry)
         log_event(
@@ -226,7 +226,7 @@ def subscribe_notifications():
     subs[user_id] = {
         "username": username,
         "subscribed": True,
-        "subscribed_at": utc_timestamp(),
+        "subscribed_at": gmt4_timestamp(),
         "opted_out": False,
     }
     save_subscriptions(subs)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
 # utils/__init__.py
 """Utility package for data storage and logging."""
 from .users import normalize_username, user_log_info
-from .timeutils import utc_timestamp, toronto_now
+from .timeutils import gmt4_timestamp, gmt4_now

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,10 +1,10 @@
 import os
-from .timeutils import utc_timestamp
+from .timeutils import gmt4_timestamp
 
 LOG_FILE = "/app/data/logs.txt"
 
 def log_event(message):
-    timestamp = utc_timestamp()
+    timestamp = gmt4_timestamp()
     full = f"[{timestamp}] {message}"
     print(full)  # ✅ Railway console logs
     try:

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -6,7 +6,7 @@ import threading
 import hashlib
 from datetime import datetime
 from .logging import log_event
-from .timeutils import toronto_now, utc_timestamp, TORONTO_TZ
+from .timeutils import gmt4_now, gmt4_timestamp
 
 SCORES_FILE = "/app/data/scores.json"
 BACKUP_FOLDER = "/app/data/backups"
@@ -156,7 +156,7 @@ def backup_scores(tag=None):
             log_event("🟡 Skipping backup — no changes since last snapshot.")
             return
 
-    timestamp = toronto_now().strftime("%Y%m%d_%H%M%S_%f")  # use microseconds
+    timestamp = gmt4_now().strftime("%Y%m%d_%H%M%S_%f")  # use microseconds
     suffix = f"_{tag}" if tag else ""
     backup_path = os.path.join(BACKUP_FOLDER, f"leaderboard_backup_{timestamp}{suffix}.json")
 

--- a/utils/timeutils.py
+++ b/utils/timeutils.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
-from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
+from datetime import datetime, timezone, timedelta
 
-TORONTO_TZ = ZoneInfo("America/Toronto")
-
-
-def toronto_now() -> datetime:
-    """Return current datetime in the Toronto timezone."""
-    return datetime.now(TORONTO_TZ)
+# Fixed GMT-4 timezone used across the app
+GMT4_TZ = timezone(timedelta(hours=-4))
 
 
-def utc_timestamp() -> str:
-    """Current timestamp in UTC derived from Toronto time."""
-    return (
-        toronto_now()
-        .astimezone(timezone.utc)
-        .isoformat(timespec="seconds")
-        .replace("+00:00", "Z")
-    )
+def gmt4_now() -> datetime:
+    """Return current datetime locked at GMT-4."""
+    return datetime.now(GMT4_TZ)
+
+
+def gmt4_timestamp() -> str:
+    """Current timestamp in GMT-4."""
+    return gmt4_now().isoformat(timespec="seconds")


### PR DESCRIPTION
## Summary
- implement fixed GMT‑4 timezone helpers
- switch logging, storage, rewards and routes to use `gmt4_timestamp`
- update backup utilities and subscriptions to use `gmt4_now`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68632576a8dc832488fb40067badb9ea