### PR TITLE
Fix referral registration bug

### DIFF
--- a/routes/user.py
+++ b/routes/user.py
@@ -11,6 +11,7 @@ user_routes = Blueprint("user_routes", __name__)
 
 @user_routes.route("/register", methods=["POST"])
 def register():
+    data = request.get_json(force=True)
     username = normalize_username(data.get("username"))
     first_name = (data.get("first_name") or "").strip()
     last_name = (data.get("last_name") or "").strip()


### PR DESCRIPTION
## Summary
- fix missing `get_json` call in `/register`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6863339e16c083248d43b04f2bfbaaf4